### PR TITLE
Enable use of nested property keys

### DIFF
--- a/deduplicate.js
+++ b/deduplicate.js
@@ -46,10 +46,10 @@ module.exports = function (RED) {
             for (i = 0; i < known_entries.length; i += 1) {
                 if (known_entries[i].key === key) {
                     if (!expired(known_entries[i])) {							
-						if (config.expirypolicy=='extend') {
-							known_entries[i].expiry=new Date().getTime() + expiry_lifetime * 1000;
-							node.storage.set(node.registry+'["'+topic+'"]',known_entries)							
-						}
+                        if (config.expirypolicy=='extend') {
+                                known_entries[i].expiry=new Date().getTime() + expiry_lifetime * 1000;
+                                node.storage.set(node.registry+'["'+topic+'"]',known_entries)							
+                        }
                         return true;
                     }
                     known_entries.splice(i, 1);
@@ -60,20 +60,20 @@ module.exports = function (RED) {
         }
 
         function getKey(payload, keyproperty) {
-	    	var properties = keyproperty.split('.')
-			var i
-			obj = payload
-
-			for (i=0; i < properties.length; i += 1){
-				if (obj.hasOwnProperty(properties[i]){
-					obj = obj[properties[i]]
-				} else {
-					// throw an error
-					console.log(`msg.payload does not contain property ${keyproperty}`
-				}
-			}
-
-			return obj
+                const properties = keyproperty.split('.');
+                let i;
+                let obj = payload;
+                
+                for (i = 0; i < properties.length; i += 1) {
+                        if (obj.hasOwnProperty(properties[i])) {
+                                obj = obj[properties[i]];
+                        } else {
+                        // key property doesn't exist, throw an error
+                        t        hrow new Error(`msg.payload does not contain payload key ${keyproperty}`);
+                        }
+                }
+                
+                return obj;
         }
 
         this.on('input', function (msg) {

--- a/deduplicate.js
+++ b/deduplicate.js
@@ -59,10 +59,27 @@ module.exports = function (RED) {
             return false;
         }
 
+        function getKey(payload, keyproperty) {
+	    	var properties = keyproperty.split('.')
+			var i
+			obj = payload
+
+			for (i=0; i < properties.length; i += 1){
+				if (obj.hasOwnProperty(properties[i]){
+					obj = obj[properties[i]]
+				} else {
+					// throw an error
+					console.log(`msg.payload does not contain property ${keyproperty}`
+				}
+			}
+
+			return obj
+        }
+
         this.on('input', function (msg) {
 
 
-            var key = node.keyproperty ? msg.payload[node.keyproperty] : msg.payload;
+            var key = node.keyproperty ? getKey(msg.payload, node.keyproperty) : msg.payload;
             var topic = (msg.topic || "default_topic")
 			var expiry_lifetime = (isNaN(parseInt(node.expiry)) ? null : parseInt(node.expiry))  || (isNaN(parseInt(msg[node.expiry])) ? null : parseInt(msg[node.expiry])) || 5
 


### PR DESCRIPTION
Enables use of a key nested in the `msg.payload` object

Example:
Given the following message `keyproperty` can be set to `packet.id` or `foo` and the cache key is correctly resolved
```json
{
  "payload": {
    "packet": {
      "id": 51244838,
      "priority": 0
    },
    "foo": "bar"
  },
  "_msgid": "asdfasdf1234"
}
```
